### PR TITLE
Fix Typo

### DIFF
--- a/_data/team_members.yml
+++ b/_data/team_members.yml
@@ -24,7 +24,7 @@
   photo: kaschube.jpg
   affiliation: Frankfurt Institute for Advanced Studies
   url: https://www.fias.science/en/fellows/detail/kaschube-matthias/
-  title: Principle Investigator
+  title: Principal Investigator
   number_educ: 0
   education1:
   education2:
@@ -36,7 +36,7 @@
   affiliation: Goethe University Frankfurt
   number_educ: 0
   url: https://www.psychologie.uni-frankfurt.de/69824239/005_Prof_-Yee-Lee-Shing
-  title: Principle Investigator
+  title: Principal Investigator
   number_educ: 0
   education1:
   education2:
@@ -47,7 +47,7 @@
   photo: toneva.jpg
   affiliation: Max Planck Institute for Software Systems
   url: http://mtoneva.com/
-  title: Principle Investigator
+  title: Principal Investigator
   number_educ: 0
   education1:
   education2:
@@ -58,7 +58,7 @@
   photo: triesch.jpg
   affiliation: Frankfurt Institute for Advanced Studies and Goethe University Frankfurt 
   url: https://www.fias.science/en/fellows/detail/triesch-jochen/
-  title: Principle Investigator
+  title: Principal Investigator
   number_educ: 0
   education1:
   education2:
@@ -69,7 +69,7 @@
   photo: vo.jpg
   affiliation: Goethe University Frankfurt
   url: https://SceneGrammarLab.com
-  title: Principle Investigator
+  title: Principal Investigator
   number_educ: 0
   education1:
   education2:


### PR DESCRIPTION
Some people have the title "principle investigator" rather than "principal investigator". This just corrects the typo.